### PR TITLE
refactor(vscode): :recycle: 取消推荐TypeScript Vue Plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "vue.volar",
-    "vue.vscode-typescript-vue-plugin",
     "antfu.unocss",
     "lokalise.i18n-ally",
     "dbaeumer.vscode-eslint",


### PR DESCRIPTION
原因：The "TypeScript Vue Plugin (Volar)" extension is no longer needed in version 2.0. Please uninstall it.  （来源：Vue-Official）
