### PR TITLE
perf(Enum): :zap: enum关键字前面加上const修饰

### DIFF
--- a/src/enums/LayoutEnum.ts
+++ b/src/enums/LayoutEnum.ts
@@ -1,7 +1,7 @@
 /**
  * 菜单布局枚举
  */
-export enum LayoutEnum {
+export const enum LayoutEnum {
   /**
    * 左侧菜单布局
    */

--- a/src/enums/MenuTypeEnum.ts
+++ b/src/enums/MenuTypeEnum.ts
@@ -1,7 +1,7 @@
 /**
  * 菜单类型枚举
  */
-export enum MenuTypeEnum {
+export const enum MenuTypeEnum {
   /**
    * 目录
    */

--- a/src/enums/ThemeEnum.ts
+++ b/src/enums/ThemeEnum.ts
@@ -1,7 +1,7 @@
 /**
  * 主题枚举
  */
-export enum ThemeEnum {
+export const enum ThemeEnum {
   /**
    * 明亮主题
    */


### PR DESCRIPTION
原因：

- Enum 成员值都是只读的，不能重新赋值。为了让这一点更醒目，通常会在 enum 关键字前面加上 const 修饰。
- 加上 const 还有一个好处，就是编译为 JavaScript 代码后，代码中 Enum 成员会被替换成对应的值，这样能提高性能表现。