### PR TITLE
fix(IconSelect): :bug: 修复构建时提示iconComponent.name可能为undefined的报错；

### DIFF
--- a/src/components/IconSelect/index.vue
+++ b/src/components/IconSelect/index.vue
@@ -169,7 +169,7 @@ function loadIcons() {
 type IconNames = keyof typeof ElementPlusIconsVue;
 const renderIcon = (iconName: string) => {
   const iconComponent = ElementPlusIconsVue[iconName as IconNames];
-  if (iconComponent) {
+  if (iconComponent && iconComponent.name) {
     return h(resolveComponent(iconComponent.name));
   }
   return null;


### PR DESCRIPTION
构建时，可能会报一个错误：
<img width="726" alt="构建错误" src="https://github.com/youlaitech/vue3-element-admin/assets/13975995/ba2fed47-bbc2-4d0e-a43f-2ad3db7e895a">
src/components/IconSelect/index.vue组件代码，resolveComponent函数的参数不能为undefined；但是缺少iconComponent.name为空的判断；
所以在外层的if里加上判断，解决报错问题；