### PR TITLE
fix:权限分配时，不分配按钮类的权限会导致页面权限也无法分配

### DIFF
--- a/src/views/system/role/index.vue
+++ b/src/views/system/role/index.vue
@@ -213,6 +213,39 @@ function handleRoleMenuSubmit() {
       });
   }
 }
+/** 选框父子不关联 */
+function handleCheck(data: any, { checkedKeys }: { checkedKeys: Array<any> }) {
+  if (checkedKeys.includes(data.value)) {
+    let node = menuRef.value.getNode(data.value);
+    selectChildren(data, true);
+    parentNodesChange(node);
+  } else {
+    selectChildren(data, false);
+  }
+}
+function selectChildren(data: { children: any[] }, checked: boolean) {
+  data &&
+    data.children &&
+    data.children.map((item) => {
+      menuRef.value.setChecked(item.value, checked);
+      if (data.children) {
+        selectChildren(item, checked);
+      }
+    });
+}
+// 父级递归
+function parentNodesChange(node: any) {
+  if (node.parent) {
+    for (let key in node) {
+      if (key == "id") {
+        menuRef.value.setChecked(node, true);
+      }
+    }
+    if (node.parent && node.id !== 0) {
+      parentNodesChange(node.parent);
+    }
+  }
+}
 
 onMounted(() => {
   handleQuery();
@@ -382,6 +415,8 @@ onMounted(() => {
           show-checkbox
           :data="menuList"
           :default-expand-all="true"
+          check-strictly
+          @check="handleCheck"
         >
           <template #default="{ data }">
             {{ data.label }}


### PR DESCRIPTION
给角色分配权限时，如果菜单下的按钮类权限不勾选会导致菜单的选框也无法进行勾选，解决:让父子 node 不联动，但选择父级会影响子级 ，具体麻烦拉下代码演示一下哦