### PR TITLE
refactor: :recycle: 去除CURD静态路由

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -54,23 +54,6 @@ export const constantRoutes: RouteRecordRaw[] = [
     ],
   },
 
-  {
-    path: "/curd",
-    component: Layout,
-    meta: {
-      alwaysShow: false,
-    },
-    children: [
-      {
-        path: "index",
-        component: () => import("@/views/demo/curd/index.vue"),
-        meta: {
-          title: "增删改查",
-        },
-      },
-    ],
-  },
-
   // 外部链接
   // {
   //   path: "/external-link",

--- a/src/views/demo/curd/index.vue
+++ b/src/views/demo/curd/index.vue
@@ -1,5 +1,14 @@
 <template>
   <div class="app-container">
+    <el-link
+      href="https://gitee.com/youlaiorg/vue3-element-admin/blob/master/src/views/demo/curd/index.vue"
+      type="primary"
+      target="_blank"
+      class="mb-10"
+    >
+      示例源码 请点击>>>>
+    </el-link>
+
     <!-- 搜索 -->
     <page-search
       ref="searchRef"


### PR DESCRIPTION
CURD是组件，还是规整到“组件封装”菜单，由后台返回路由地址。如果要体验的话，还是需要大大新增一个菜单指向 curd 组件示例地址
列表选择组件也是一样