### PR TITLE
ci: :ferris_wheel: 规整脚本执行命令

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,3 @@
-## 开发环境
-NODE_ENV='development'
-
 # 应用端口
 VITE_APP_PORT = 3000
 

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,3 @@
-## 生产环境
-NODE_ENV='production'
-
 # 代理前缀
 VITE_APP_BASE_API = '/prod-api'
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
-    "dev": "vite serve --mode development",
-    "build:prod": "vite build --mode production && vue-tsc --noEmit",
-    "prepare": "husky",
+    "dev": "vite",
+    "build": "vue-tsc --noEmit & vite build",
+    "preview": "vite preview",
+    "build-only": "vite build",
+    "type-check": "vue-tsc --noEmit",
     "lint:eslint": "eslint  --fix --ext .ts,.js,.vue ./src ",
     "lint:prettier": "prettier --write \"**/*.{js,cjs,ts,json,tsx,css,less,scss,vue,html,md}\"",
     "lint:stylelint": "stylelint  \"**/*.{css,scss,vue}\" --fix",
     "lint:lint-staged": "lint-staged",
+    "preinstall": "npx only-allow pnpm",
+    "prepare": "husky",
     "commit": "git-cz"
   },
   "config": {


### PR DESCRIPTION
pnpm run build:prod 时提示：
NODE_ENV=production is not supported in the .env file. Only NODE_ENV=development is supported to create a development build of your project. If you need to set process.env.NODE_ENV, you can set it in the Vite config instead.

所以去除了 .env 文件中的 NODE_ENV 变量，如果需要的话得在 vite 配置文件的 define 中配置

去除 --mode 参数（默认情况下，开发服务器 (dev 命令) 运行在 development (开发) 模式，而 build 命令则运行在 production (生产) 模式）

增加了ts类型检测命令、预览命令、仅打包命令