### PR TITLE
feat(PageModal): :sparkles: 表单项增加文本类型支持

### DIFF
--- a/src/components/PageModal/Form.vue
+++ b/src/components/PageModal/Form.vue
@@ -26,15 +26,7 @@
         </template>
         <!-- Input 输入框 -->
         <template v-if="item.type === 'input' || item.type === undefined">
-          <template v-if="item.attrs?.type === 'number'">
-            <el-input
-              v-model.number="formData[item.prop]"
-              v-bind="item.attrs"
-            />
-          </template>
-          <template v-else>
-            <el-input v-model="formData[item.prop]" v-bind="item.attrs" />
-          </template>
+          <el-input v-model="formData[item.prop]" v-bind="item.attrs" />
         </template>
         <!-- Select 选择器 -->
         <template v-else-if="item.type === 'select'">
@@ -71,6 +63,10 @@
         <!-- DatePicker 日期选择器 -->
         <template v-else-if="item.type === 'date-picker'">
           <el-date-picker v-model="formData[item.prop]" v-bind="item.attrs" />
+        </template>
+        <!-- Text 文本 -->
+        <template v-else-if="item.type === 'text'">
+          <el-text v-bind="item.attrs">{{ formData[item.prop] }}</el-text>
         </template>
         <!-- 自定义 -->
         <template v-else-if="item.type === 'custom'">

--- a/src/components/PageModal/types.ts
+++ b/src/components/PageModal/types.ts
@@ -28,6 +28,7 @@ export type IFormItems<T = any> = Array<{
     | "tree-select"
     | "date-picker"
     | "input-number"
+    | "text"
     | "custom";
   // 组件属性
   attrs?: IObject;


### PR DESCRIPTION
- text类型可以用于仅做数据展示的表单项，值可以是通过 computed 函数计算返回

- 去除 el-input 的 v-model.number 修饰功能（官方文档说是不支持修饰，实测是可以的，但是有bug，无法输入 0.01，会自动重置为 0），可以使用 el-input-number 组件替代