### PR TITLE
fix: :bug: 修复左侧布局移动端菜单弹出样式

### DIFF
--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -285,4 +285,15 @@ watch(route, () => {
     }
   }
 }
+
+.mobile {
+  .main-container {
+    margin-left: 0;
+  }
+
+  &.layout-top {
+    // 顶部模式全局变量修改
+    --el-menu-item-height: $navbar-height;
+  }
+}
 </style>


### PR DESCRIPTION
原移动端左侧布局菜单打开时遮罩是在页面上的 而[重构布局样式](https://github.com/youlaitech/vue3-element-admin/pull/116)后导致该效果丢失 现已修复