### PR TITLE
feat(PageContent): :sparkles: 支持表格远程筛选

### DIFF
--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -13,11 +13,13 @@ function usePage() {
 
   // 搜索
   function handleQueryClick(queryParams: IObject) {
-    contentRef.value?.fetchPageData(queryParams, true);
+    const filterParams = contentRef.value?.getFilterParams();
+    contentRef.value?.fetchPageData({ ...queryParams, ...filterParams }, true);
   }
   // 重置
   function handleResetClick(queryParams: IObject) {
-    contentRef.value?.fetchPageData(queryParams, true);
+    const filterParams = contentRef.value?.getFilterParams();
+    contentRef.value?.fetchPageData({ ...queryParams, ...filterParams }, true);
   }
   // 新增
   function handleAddClick() {
@@ -45,6 +47,11 @@ function usePage() {
   function handleSearchClick() {
     searchRef.value?.toggleVisible();
   }
+  // 涮选数据
+  function handleFilterChange(filterParams) {
+    const queryParams = searchRef.value?.getQueryParams();
+    contentRef.value?.fetchPageData({ ...queryParams, ...filterParams }, true);
+  }
 
   return {
     searchRef,
@@ -58,6 +65,7 @@ function usePage() {
     handleSubmitClick,
     handleExportClick,
     handleSearchClick,
+    handleFilterChange,
   };
 }
 

--- a/src/views/demo/curd/config/content.ts
+++ b/src/views/demo/curd/config/content.ts
@@ -1,4 +1,5 @@
 import UserAPI from "@/api/user";
+import RoleAPI from "@/api/role";
 import type { UserQuery } from "@/api/user/model";
 import type { IContentConfig } from "@/components/PageContent/index.vue";
 
@@ -45,6 +46,22 @@ const contentConfig: IContentConfig<UserQuery> = {
     { label: "用户昵称", align: "center", prop: "nickname", width: 120 },
     { label: "性别", align: "center", prop: "genderLabel", width: 100 },
     { label: "部门", align: "center", prop: "deptName", width: 120 },
+    {
+      label: "角色",
+      align: "center",
+      prop: "roleNames",
+      width: 120,
+      columnKey: "roleIds",
+      filters: [],
+      filterMultiple: true,
+      filterJoin: ",",
+      async initFn(colItem) {
+        const roleOptions = await RoleAPI.getOptions();
+        colItem.filters = roleOptions.map((item) => {
+          return { text: item.label, value: item.value };
+        });
+      },
+    },
     { label: "手机号码", align: "center", prop: "mobile", width: 120 },
     {
       label: "状态",

--- a/src/views/demo/curd/index.vue
+++ b/src/views/demo/curd/index.vue
@@ -27,6 +27,7 @@
       @search-click="handleSearchClick"
       @toolbar-click="handleToolbarClick"
       @operat-click="handleOperatClick"
+      @filter-change="handleFilterChange"
     >
       <template #status="scope">
         <el-tag :type="scope.row[scope.prop] == 1 ? 'success' : 'info'">
@@ -81,6 +82,7 @@ const {
   handleSubmitClick,
   handleExportClick,
   handleSearchClick,
+  handleFilterChange,
 } = usePage();
 // 编辑
 async function handleEditClick(row: IObject) {


### PR DESCRIPTION
对有分页的表格来说，就本页的数据筛选显得意义不大... 特此支持表格的远程数据筛选
PS：如果存在搜索表单，那么相同字段会优先使用表格中的条件

![91B99070-C714-476c-B1F0-61BAA3399438](https://github.com/youlaitech/vue3-element-admin/assets/31907940/f6284034-c0ba-4da3-92d4-1335c79295bf)
