### PR TITLE
feat(PageContent): ✨ 左侧工具栏增加type配置参数

### DIFF
--- a/src/components/CURD/PageContent.vue
+++ b/src/components/CURD/PageContent.vue
@@ -46,7 +46,7 @@
             <el-button
               v-hasPerm="[`${contentConfig.pageName}:${item.auth}`]"
               :icon="item.icon"
-              type="default"
+              :type="item.type ?? 'default'"
               @click="handleToolbar(item.name)"
             >
               {{ item.text }}

--- a/src/components/CURD/types.ts
+++ b/src/components/CURD/types.ts
@@ -108,6 +108,7 @@ export interface IContentConfig<T = any> {
         icon?: string;
         name: string;
         text: string;
+        type?: "primary" | "success" | "warning" | "danger" | "info";
       }
   >;
   // 表格工具栏右侧图标

--- a/src/views/demo/curd/config/content.ts
+++ b/src/views/demo/curd/config/content.ts
@@ -49,6 +49,13 @@ const contentConfig: IContentConfig<UserQuery> = {
       text: "导入",
       auth: "import",
     },
+    {
+      name: "custom1",
+      icon: "plus",
+      text: "自定义1",
+      auth: "import",
+      type: "info",
+    },
   ],
   defaultToolbar: ["refresh", "filter", "imports", "exports", "search"],
   cols: [


### PR DESCRIPTION
左侧工具栏自定义按钮目前是写死 `typf="default"`的，实际需求中，会有自定义的需求。 