### PR TITLE
修复《IconSelect》切换 Tab name丢失，导致的eleme…nt图标回显不正确。

### DIFF
--- a/src/components/IconSelect/index.vue
+++ b/src/components/IconSelect/index.vue
@@ -126,7 +126,7 @@ function loadIcons() {
 }
 
 function handleTabClick(tabPane: any) {
-  activeTab.value = tabPane.name;
+  activeTab.value = tabPane.props.name;
   filterIcons();
 }
 


### PR DESCRIPTION
修复《IconSelect》切换 Tab name丢失，导致的eleme…nt图标回显不正确。

修复前：
![截屏2025-01-21 15 16 07](https://github.com/user-attachments/assets/75d12e75-d420-4399-9c52-2d327c244339)

修复后：
![截屏2025-01-21 15 16 27](https://github.com/user-attachments/assets/4f7ee440-e02a-4752-a018-4a81e80fe2ab)

