### PR TITLE
pagination组件修改

### DIFF
--- a/src/components/Pagination/index.vue
+++ b/src/components/Pagination/index.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-defineProps({
+const props = defineProps({
   total: {
     required: true,
     type: Number as PropType<number>,
@@ -59,7 +59,19 @@ const pageSize = defineModel("limit", {
   default: 10,
 });
 
+watch(
+  props.total,
+  (newVal: number) => {
+    const lastPage = Math.ceil(newVal / pageSize.value)
+    if (newVal > 0 && currentPage.value > lastPage) {
+      currentPage.value = lastPage
+      emit("pagination", { page: currentPage.value, limit: pageSize.value });
+    }
+  }
+);
+
 function handleSizeChange(val: number) {
+  currentPage.value = 1
   emit("pagination", { page: currentPage.value, limit: val });
 }
 


### PR DESCRIPTION
问题一：分页列表最后一页只有一条数据，在这种情况下执行删除操作，删除成功后（多数情况下产品经理不会允许删除一条数据就要重新回到第一页），currentPage的值不会更新，此时刷新列表会出现currentPage大于总页数的情况
方案：在公共组件内监听total，如果出现以上情况，更新currentPage，再刷新列表

问题二：修改每页条数pageSize后，需要把currentPage值置为1，否则可能出现修改pageSize后总页数小于currentPage的情况
方案：修改后currentPage值置为1