### PR TITLE
fix: :bug: 角色管理关键字查询加上防抖

### DIFF
--- a/src/views/system/role/index.vue
+++ b/src/views/system/role/index.vue
@@ -262,6 +262,7 @@ const parentChildLinked = ref(true);
 
 // 查询
 function handleQuery() {
+  if (loading.value) return;
   loading.value = true;
   RoleAPI.getPage(queryParams)
     .then((data) => {


### PR DESCRIPTION
问题：目前角色管理页面进行关键字查询，一直回车或者点搜索的话，会频繁调用很多次接口
本次改动：loading的时候再次触发不进行请求，相当于加上防抖
问题复现截图：
![image](https://github.com/user-attachments/assets/5cf598b4-1a10-4950-961b-b5040953d2b3)
