### PR TITLE
feat(项目配置控件): 新增可自定义的操作卡片定位，支持i18n

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,8 +6,8 @@ VITE_APP_TITLE=vue3-element-admin
 VITE_APP_BASE_API=/dev-api
 
 # 接口地址
-VITE_APP_API_URL=https://api.youlai.tech # 线上
-# VITE_APP_API_URL=http://localhost:8989    # 本地
+# VITE_APP_API_URL=https://api.youlai.tech # 线上
+VITE_APP_API_URL=http://localhost:8989    # 本地
 
 # WebSocket 端点（不配置则关闭），线上 ws://api.youlai.tech/ws ，本地 ws://localhost:8989/ws
 VITE_APP_WS_ENDPOINT=

--- a/src/constants/storage-keys.ts
+++ b/src/constants/storage-keys.ts
@@ -19,6 +19,7 @@ export const LAYOUT_KEY = "layout";
 export const SIDEBAR_COLOR_SCHEME_KEY = "sidebarColorScheme";
 export const THEME_KEY = "theme";
 export const THEME_COLOR_KEY = "themeColor";
+export const ACTION_FOOTER_MODE_KEY = "actionFooterMode";
 
 // 🎯 功能分组的键映射对象
 
@@ -43,6 +44,7 @@ export const SETTINGS_KEYS = {
   LAYOUT: LAYOUT_KEY,
   THEME_COLOR: THEME_COLOR_KEY,
   THEME: THEME_KEY,
+  ACTION_FOOTER_MODE: ACTION_FOOTER_MODE_KEY,
 } as const;
 
 // 📦 所有存储键的统一集合

--- a/src/enums/settings/layout.enum.ts
+++ b/src/enums/settings/layout.enum.ts
@@ -51,3 +51,18 @@ export const enum ComponentSize {
    */
   SMALL = "small",
 }
+
+/**
+ * 设置抽屉底部操作区域布局模式
+ */
+export const enum ActionFooterMode {
+  /**
+   * 固定到底部（抽屉外层，覆盖）
+   */
+  FIXED_BOTTOM = "fixed_bottom",
+
+  /**
+   * 抽屉之内（随内容滚动，保持布局）
+   */
+  INSIDE_DRAWER = "inside_drawer",
+}

--- a/src/lang/package/en.ts
+++ b/src/lang/package/en.ts
@@ -69,6 +69,7 @@ export default {
     theme: "Theme",
     interface: "Interface",
     navigation: "Navigation",
+    operationArea: "Operation Area",
     themeColor: "Theme Color",
     showTagsView: "Show Tags View",
     showAppLogo: "Show App Logo",
@@ -92,5 +93,7 @@ export default {
     copyConfigDescription:
       "Generate current settings code and copy to clipboard, then overwrite src/settings.ts file",
     resetConfigDescription: "Restore all settings to system default values",
+    actionFooterFixed: "Fixed Bottom",
+    actionFooterInside: "Inside Drawer",
   },
 };

--- a/src/lang/package/zh-cn.ts
+++ b/src/lang/package/zh-cn.ts
@@ -69,6 +69,7 @@ export default {
     theme: "主题设置",
     interface: "界面设置",
     navigation: "导航设置",
+    operationArea: "操作区域",
     themeColor: "主题颜色",
     themeColorTip: "主题颜色",
     darkMode: "暗黑模式",
@@ -93,5 +94,7 @@ export default {
     configManagement: "配置管理",
     copyConfigDescription: "生成当前设置的代码并复制到剪贴板，然后覆盖 src/settings.ts 文件",
     resetConfigDescription: "恢复所有设置为系统默认值",
+    actionFooterFixed: "固定底部",
+    actionFooterInside: "抽屉之内",
   },
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,11 @@
-import { LayoutMode, ComponentSize, SidebarColor, ThemeMode, LanguageEnum } from "./enums";
+import {
+  LayoutMode,
+  ComponentSize,
+  SidebarColor,
+  ThemeMode,
+  LanguageEnum,
+  ActionFooterMode,
+} from "./enums";
 
 const { pkg } = __APP_INFO__;
 
@@ -32,6 +39,8 @@ export const defaultSettings: AppSettings = {
   watermarkContent: pkg.name,
   // 侧边栏配色方案
   sidebarColorScheme: SidebarColor.CLASSIC_BLUE,
+  // 抽屉底部操作区域布局模式
+  actionFooterMode: ActionFooterMode.FIXED_BOTTOM,
 };
 
 // 主题色预设 - 经典配色方案

--- a/src/store/modules/settings-store.ts
+++ b/src/store/modules/settings-store.ts
@@ -1,6 +1,7 @@
 import { defaultSettings } from "@/settings";
 import { SidebarColor, ThemeMode } from "@/enums/settings/theme.enum";
 import type { LayoutMode } from "@/enums/settings/layout.enum";
+import { ActionFooterMode } from "@/enums";
 import { applyTheme, generateThemeColors, toggleDarkMode, toggleSidebarColor } from "@/utils/theme";
 import { SETTINGS_KEYS } from "@/constants";
 
@@ -15,6 +16,7 @@ interface SettingsState {
   // 布局设置
   layout: LayoutMode;
   sidebarColorScheme: string;
+  actionFooterMode: ActionFooterMode;
 
   // 主题设置
   theme: ThemeMode;
@@ -53,6 +55,11 @@ export const useSettingsStore = defineStore("setting", () => {
 
   const theme = useStorage<ThemeMode>(SETTINGS_KEYS.THEME, defaultSettings.theme);
 
+  const actionFooterMode = useStorage<ActionFooterMode>(
+    SETTINGS_KEYS.ACTION_FOOTER_MODE,
+    defaultSettings.actionFooterMode
+  );
+
   // 🎯 设置项映射
   const settingsMap = {
     showTagsView,
@@ -60,6 +67,7 @@ export const useSettingsStore = defineStore("setting", () => {
     showWatermark,
     sidebarColorScheme,
     layout,
+    actionFooterMode,
   } as const;
 
   // 🎯 监听器 - 主题变化
@@ -107,6 +115,10 @@ export const useSettingsStore = defineStore("setting", () => {
     layout.value = newLayout;
   }
 
+  function updateActionFooterMode(newMode: ActionFooterMode): void {
+    actionFooterMode.value = newMode;
+  }
+
   // 🎯 设置面板显示控制
   function toggleSettingsPanel(): void {
     settingsVisible.value = !settingsVisible.value;
@@ -129,6 +141,7 @@ export const useSettingsStore = defineStore("setting", () => {
     layout.value = defaultSettings.layout as LayoutMode;
     themeColor.value = defaultSettings.themeColor;
     theme.value = defaultSettings.theme;
+    actionFooterMode.value = defaultSettings.actionFooterMode;
   }
 
   return {
@@ -141,6 +154,7 @@ export const useSettingsStore = defineStore("setting", () => {
     layout,
     themeColor,
     theme,
+    actionFooterMode,
 
     // 更新方法
     updateSetting,
@@ -148,6 +162,7 @@ export const useSettingsStore = defineStore("setting", () => {
     updateThemeColor,
     updateSidebarColorScheme,
     updateLayout,
+    updateActionFooterMode,
 
     // 面板控制
     toggleSettingsPanel,

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -78,6 +78,8 @@ declare global {
     watermarkContent: string;
     /** 侧边栏配色方案 */
     sidebarColorScheme: "classic-blue" | "minimal-white";
+    /** 操作区布局模式 */
+    actionFooterMode: import("@/enums").ActionFooterMode;
   }
 
   /**


### PR DESCRIPTION
您好，我是Java Vue 生态的全栈开发，很高兴今天能遇到这个项目，希望一同为开源社区贡献自己的力量~

[ 一、前端布局问题 ]

1、默认情况下，项目配置时，action-card 固定底部会闪动bug，而且在抽屉之外有点怪，所以我按照规范 新增功能支持用户像设置布局一样设置 action-card 定位，并且同步支持i18n 。 
2、在设置抽屉“操作区域”选择“抽屉之内”时。el-drawer__body 高度行为异常导致出现额外滚动条，且 主题设置 分割线顶部出现不期望的额外空隙


GIF动图看解决的问题
![youlai-vue3ts项目配置闪动溢出bug](https://github.com/user-attachments/assets/f50c3111-be15-4fb9-87f9-29774c113c93)

[ 二、本次提交新增功能和优化设计  ]

**（1）新增设置项：操作区布局模式（ActionFooterMode），支持两种模式：**
              ① 固定底部（fixed_bottom）
              ② 抽屉之内（inside_drawer）

**（2）新增 i18n：**
settings.operationArea（操作区域）
settings.actionFooterFixed（固定底部）
settings.actionFooterInside（抽屉之内）
配置复制增强：generateSettingsCode 输出 actionFooterMode.

**效果图**

<img width="2462" height="1445" alt="image" src="https://github.com/user-attachments/assets/87b49125-e851-4c3e-a3e6-7ddaecb902ac" />


<img width="2478" height="1441" alt="image" src="https://github.com/user-attachments/assets/c1932206-32af-4434-a6ed-51a970fc1a41" />
